### PR TITLE
ci: drop Node 20 from npm package build matrix

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -39,7 +39,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [22.x, 24.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:


### PR DESCRIPTION
## Summary

Node.js 20 reached end-of-life. The Deno workflow builds the npm package with a Node matrix; this removes **20.x** so only **22.x** and **24.x** are used.

## Changes

- `.github/workflows/deno.yml`: `node-version` matrix `[20.x, 22.x, 24.x]` → `[22.x, 24.x]`.

Made with [Cursor](https://cursor.com)