### PR TITLE
fix: resolve @std/assert via import map in tests

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -10,7 +10,7 @@
     "exclude": ["npm"]
   },
   "imports": {
-    "assert": "jsr:@std/assert@^1.0.15",
+    "@std/assert": "jsr:@std/assert@^1.0.15",
     "dnt": "jsr:@deno/dnt@^0.42.3"
   }
 }

--- a/mod_test.ts
+++ b/mod_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "assert"
+import { assertEquals } from "@std/assert"
 import { katakanaToMora } from "./mod.ts"
 
 Deno.test("サ|ル", () => {


### PR DESCRIPTION
## Summary

CI on the Deno **test** job was failing with:

`Module '"assert"' has no exported member 'assertEquals'.`

That happens when the bare specifier `assert` is resolved as Node’s built-in `assert` during type-checking on recent Deno 2.x runners, instead of the JSR mapping in `deno.json`.

## Changes

- `deno.json`: rename the import map key from `assert` to `@std/assert` (matches Deno/jsr conventions and avoids the Node name clash).
- `mod_test.ts`: import `assertEquals` from `@std/assert`.

This is unrelated to the Node.js matrix in PR #14; **master would hit the same failure** on current CI once the runner picks up a Deno release that surfaces this behavior.

## Verification

- `deno fmt --check`, `deno lint`, `deno test --coverage=cov_profile`, `deno coverage cov_profile` (local Deno 2.5.4).

Made with [Cursor](https://cursor.com)